### PR TITLE
Feature/#49

### DIFF
--- a/src/main/java/umc/duckmelang/domain/memberprofileimage/dto/MemberProfileImageRequestDto.java
+++ b/src/main/java/umc/duckmelang/domain/memberprofileimage/dto/MemberProfileImageRequestDto.java
@@ -17,10 +17,5 @@ public class MemberProfileImageRequestDto {
     public static class MemberProfileImageDto {
         private Long imageId;
         private boolean publicStatus;
-
-//        @JsonGetter("isPublic") // JSON 직렬화 시 "isPublic"으로 설정
-//        public boolean isPublic() {
-//            return isPublic;
-//        }
     }
 }

--- a/src/main/java/umc/duckmelang/domain/memberprofileimage/dto/MemberProfileImageRequestDto.java
+++ b/src/main/java/umc/duckmelang/domain/memberprofileimage/dto/MemberProfileImageRequestDto.java
@@ -16,12 +16,11 @@ public class MemberProfileImageRequestDto {
     @NoArgsConstructor
     public static class MemberProfileImageDto {
         private Long imageId;
+        private boolean publicStatus;
 
-        private boolean isPublic;
-
-        @JsonGetter("isPublic") // JSON 직렬화 시 "isPublic"으로 설정
-        public boolean isPublic() {
-            return isPublic;
-        }
+//        @JsonGetter("isPublic") // JSON 직렬화 시 "isPublic"으로 설정
+//        public boolean isPublic() {
+//            return isPublic;
+//        }
     }
 }

--- a/src/main/java/umc/duckmelang/domain/memberprofileimage/service/MemberProfileImageCommandServiceImpl.java
+++ b/src/main/java/umc/duckmelang/domain/memberprofileimage/service/MemberProfileImageCommandServiceImpl.java
@@ -46,7 +46,7 @@ public class MemberProfileImageCommandServiceImpl implements MemberProfileImageC
                 .orElseThrow(() -> new MemberProfileImageException(ErrorStatus.MEMBERPROFILEIMAGE_NOT_FOUND));
 
         //프로필 이미지 공개 범위 변경
-        MemberProfileImage updatedProfileImage = MemberProfileImageConverter.toMemberProfileImageWithChangedStatus(profileImage, request.isPublic());
+        MemberProfileImage updatedProfileImage = MemberProfileImageConverter.toMemberProfileImageWithChangedStatus(profileImage, request.isPublicStatus());
 
         return memberProfileImageRepository.save(updatedProfileImage);
     }


### PR DESCRIPTION
## 개요
- 프로필 사진 공개 전환 불가 문제 해결
- 프로필 사진 조회 관련해서는, 지우님이 작성해주신 Dto 사용중이었어서 이미 createdAt 잘 나오고 있더라구요! 이 부분 관련해서 코드 수정은 없습니다.

## PR 유형
어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
