### PR TITLE
bug: 생년월일 설정, 게시글 내 이벤트 날짜 설정 오류 해결

### DIFF
--- a/src/main/java/umc/duckmelang/domain/member/domain/Member.java
+++ b/src/main/java/umc/duckmelang/domain/member/domain/Member.java
@@ -1,5 +1,6 @@
 package umc.duckmelang.domain.member.domain;
 
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import jakarta.persistence.*;
 import lombok.*;
 import umc.duckmelang.domain.auth.domain.Auth;
@@ -16,6 +17,7 @@ import umc.duckmelang.domain.landmine.domain.Landmine;
 import umc.duckmelang.global.apipayload.code.status.ErrorStatus;
 import umc.duckmelang.global.apipayload.exception.MemberException;
 import umc.duckmelang.global.common.BaseEntity;
+import umc.duckmelang.global.common.serializer.LocalDateSerializer;
 
 import java.time.LocalDate;
 import java.util.*;
@@ -39,6 +41,7 @@ public class Member extends BaseEntity {
     private String introduction;
 
     @Column(nullable = true)
+    @JsonSerialize(using = LocalDateSerializer.class)
     private LocalDate birth;
 
     @Enumerated(EnumType.STRING)

--- a/src/main/java/umc/duckmelang/domain/post/domain/Post.java
+++ b/src/main/java/umc/duckmelang/domain/post/domain/Post.java
@@ -1,6 +1,7 @@
 package umc.duckmelang.domain.post.domain;
 
 
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -13,6 +14,7 @@ import umc.duckmelang.domain.postimage.domain.PostImage;
 import umc.duckmelang.global.apipayload.code.status.ErrorStatus;
 import umc.duckmelang.global.apipayload.exception.PostException;
 import umc.duckmelang.global.common.BaseEntity;
+import umc.duckmelang.global.common.serializer.LocalDateSerializer;
 
 import java.time.LocalDate;
 import java.util.*;
@@ -40,6 +42,7 @@ public class Post extends BaseEntity {
     private String title;
 
     @Column(name = "event_date", columnDefinition = "DATE", nullable = false)
+    @JsonSerialize(using = LocalDateSerializer.class)
     private LocalDate eventDate;
 
     @Column(name = "wanted", columnDefinition = "BIT", nullable = false)

--- a/src/main/java/umc/duckmelang/global/common/serializer/LocalDateSerializer.java
+++ b/src/main/java/umc/duckmelang/global/common/serializer/LocalDateSerializer.java
@@ -1,0 +1,26 @@
+package umc.duckmelang.global.common.serializer;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.ser.std.StdSerializer;
+
+import java.io.IOException;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+
+public class LocalDateSerializer extends StdSerializer<LocalDate> {
+    private static final DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+
+    public LocalDateSerializer() {
+        this(null);
+    }
+
+    public LocalDateSerializer(Class<LocalDate> t) {
+        super(t);
+    }
+
+    @Override
+    public void serialize(LocalDate value, JsonGenerator gen, SerializerProvider provider) throws IOException {
+        gen.writeString(value.format(formatter));
+    }
+}

--- a/src/main/java/umc/duckmelang/global/config/JacksonConfig.java
+++ b/src/main/java/umc/duckmelang/global/config/JacksonConfig.java
@@ -2,10 +2,13 @@ package umc.duckmelang.global.config;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.module.SimpleModule;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import umc.duckmelang.global.common.serializer.LocalDateSerializer;
 import umc.duckmelang.global.common.serializer.LocalDateTimeSerializer;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 @Configuration
@@ -16,9 +19,12 @@ public class JacksonConfig {
         SimpleModule module = new SimpleModule();
         // 내가 커스텀한 직렬화기를 추가한다.
         module.addSerializer(LocalDateTime.class, new LocalDateTimeSerializer());
+        module.addSerializer(LocalDate.class, new LocalDateSerializer());
 
         ObjectMapper mapper = new ObjectMapper();
+        mapper.registerModule(new JavaTimeModule()); // JavaTimeModule 등록
         mapper.registerModule(module);
+
         return mapper;
     }
 }

--- a/src/main/java/umc/duckmelang/global/redis/refreshtoken/RefreshToken.java
+++ b/src/main/java/umc/duckmelang/global/redis/refreshtoken/RefreshToken.java
@@ -17,6 +17,7 @@ public class RefreshToken{
     private String token;
 
     private Long memberId;
+
     private LocalDateTime expiryDate;
 
     @Builder


### PR DESCRIPTION

## 개요
[Refactor] response body의 created_at 형식 통일 https://github.com/duckmelang/duckmelang-backend/issues/75 를 진행하며 생겨 커스텀 직렬화기를 구현했는데, 이게 LocalDate를 사용하는 birth 속성에도 영향을 미치고 있어 닉네임, 생년월일, 성별 설정 API와 게시글 작성 API 실행 시 오류가 발생합니다.

Jackson 라이브러리가 Java 8의 날짜 및 시간 타입인 LocalDate를 기본적으로 지원하지 않기 때문에 발생한 문제로, ObjectMapper에 JavaTimeModule을 등록하고 LocalDateSerializer를 커스텀함으로서 문제를 해결했습니다.

Swagger를 통해 테스트 완료하였습니다.
![스크린샷 2025-02-07 오후 3 06 02](https://github.com/user-attachments/assets/96079a48-4325-4cd7-b0cb-ec995cdeb631)



## PR 유형
어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
