### PR TITLE
Feature/#102 알림 읽음/삭제 & 알림 설정 관련 API 구현

### DIFF
--- a/src/main/java/umc/duckmelang/domain/bookmark/controller/BookmarkRestController.java
+++ b/src/main/java/umc/duckmelang/domain/bookmark/controller/BookmarkRestController.java
@@ -20,7 +20,7 @@ import umc.duckmelang.global.apipayload.ApiResponse;
 @RestController
 @RequiredArgsConstructor
 @Validated
-public class BookmarkController {
+public class BookmarkRestController {
 
     private final BookmarkQueryService bookmarkQueryService;
     private final BookmarkCommandService bookmarkCommandService;

--- a/src/main/java/umc/duckmelang/domain/bookmark/service/BookmarkCommandServiceImpl.java
+++ b/src/main/java/umc/duckmelang/domain/bookmark/service/BookmarkCommandServiceImpl.java
@@ -11,6 +11,8 @@ import umc.duckmelang.domain.idolcategory.domain.IdolCategory;
 import umc.duckmelang.domain.member.domain.Member;
 import umc.duckmelang.domain.member.repository.MemberRepository;
 import umc.duckmelang.domain.notification.service.NotificationCommandService;
+import umc.duckmelang.domain.notificationsetting.domain.NotificationSetting;
+import umc.duckmelang.domain.notificationsetting.service.NotificationSettingQueryService;
 import umc.duckmelang.domain.post.converter.PostConverter;
 import umc.duckmelang.domain.post.domain.Post;
 import umc.duckmelang.domain.post.dto.PostRequestDto;
@@ -36,6 +38,7 @@ public class BookmarkCommandServiceImpl implements BookmarkCommandService {
     private final PostRepository postRepository;
     private final MemberRepository memberRepository;
     private final NotificationCommandService notificationCommandService;
+    private final NotificationSettingQueryService notificationSettingQueryService;
     private final PostImageQueryService postImageQueryService;
 
     @Override
@@ -51,9 +54,12 @@ public class BookmarkCommandServiceImpl implements BookmarkCommandService {
         String postImageUrl = (postThumbnail != null) ? postThumbnail.getPostImageUrl() : null;
 
         Bookmark bookmark = BookmarkConverter.toBookmark(member, post);
-        notificationCommandService.send(
-                member, post.getMember(), BOOKMARK, "내 동행글이 스크랩되었어요", postImageUrl
-        );
+        NotificationSetting notificationSetting = notificationSettingQueryService.findNotificationSetting(post.getMember().getId());
+        if(notificationSetting.getBookmarkNotificationEnabled()){
+            notificationCommandService.send(
+                    member, post.getMember(), BOOKMARK, "내 동행글이 스크랩되었어요", postImageUrl
+            );
+        }
         return bookmarkRepository.save(bookmark);
     }
 }

--- a/src/main/java/umc/duckmelang/domain/member/domain/Member.java
+++ b/src/main/java/umc/duckmelang/domain/member/domain/Member.java
@@ -8,6 +8,8 @@ import umc.duckmelang.domain.materelationship.domain.MateRelationship;
 import umc.duckmelang.domain.member.domain.enums.Gender;
 import umc.duckmelang.domain.memberidol.domain.MemberIdol;
 import umc.duckmelang.domain.memberprofileimage.domain.MemberProfileImage;
+import umc.duckmelang.domain.notification.domain.Notification;
+import umc.duckmelang.domain.notificationsetting.domain.NotificationSetting;
 import umc.duckmelang.domain.post.domain.Post;
 import umc.duckmelang.domain.review.domain.Review;
 import umc.duckmelang.domain.memberevent.domain.MemberEvent;
@@ -112,6 +114,11 @@ public class Member extends BaseEntity {
     @OneToMany(mappedBy = "secondMember", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<MateRelationship> mateRelationshipinSecondList = new ArrayList<>();
 
+    //notificationSetting
+    @OneToOne(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
+    private NotificationSetting notificationSetting;
+
+
     // 비밀번호 설정 함수
     public void encodePassword(String password){
         this.password=password;
@@ -155,6 +162,7 @@ public class Member extends BaseEntity {
         this.nickname = nickname;
         this.introduction = introduction;
     }
+
 
     public Member(Long id) {
         this.id = id;

--- a/src/main/java/umc/duckmelang/domain/member/service/member/MemberCommandServiceImpl.java
+++ b/src/main/java/umc/duckmelang/domain/member/service/member/MemberCommandServiceImpl.java
@@ -19,6 +19,8 @@ import umc.duckmelang.domain.memberevent.domain.MemberEvent;
 import umc.duckmelang.domain.memberevent.repository.MemberEventRepository;
 import umc.duckmelang.domain.memberidol.domain.MemberIdol;
 import umc.duckmelang.domain.memberidol.repository.MemberIdolRepository;
+import umc.duckmelang.domain.notificationsetting.domain.NotificationSetting;
+import umc.duckmelang.domain.notificationsetting.repository.NotificationSettingRepository;
 import umc.duckmelang.global.apipayload.code.status.ErrorStatus;
 import umc.duckmelang.global.apipayload.exception.EventCategoryException;
 import umc.duckmelang.global.apipayload.exception.IdolCategoryException;
@@ -41,6 +43,7 @@ public class MemberCommandServiceImpl implements MemberCommandService {
     private final EventCategoryRepository eventCategoryRepository;
     private final MemberEventRepository memberEventRepository;
     private final LandmineRepository landmineRepository;
+    private final NotificationSettingRepository notificationSettingRepository;
 
     @Override
     @Transactional
@@ -50,7 +53,21 @@ public class MemberCommandServiceImpl implements MemberCommandService {
         }
         Member newMember = MemberConverter.toMember(request);
         newMember.encodePassword(passwordEncoder.encode(request.getPassword()));
-        return memberRepository.save(newMember);
+        newMember = memberRepository.save(newMember);
+
+        // 알림 설정 자동 추가
+        NotificationSetting notificationSetting = NotificationSetting.builder()
+                .member(newMember)
+                .chatNotificationEnabled(true)  // 기본값을 true로 설정
+                .requestNotificationEnabled(true)
+                .reviewNotificationEnabled(true)
+                .bookmarkNotificationEnabled(true)
+                .build();
+
+        notificationSettingRepository.save(notificationSetting);
+        newMember.setNotificationSetting(notificationSetting);
+
+        return newMember;
     }
 
     @Override

--- a/src/main/java/umc/duckmelang/domain/notification/controller/NotificationController.java
+++ b/src/main/java/umc/duckmelang/domain/notification/controller/NotificationController.java
@@ -9,10 +9,12 @@ import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 import umc.duckmelang.domain.notification.converter.NotificationConverter;
 import umc.duckmelang.domain.notification.domain.Notification;
 import umc.duckmelang.domain.notification.dto.NotificationResponseDto;
+import umc.duckmelang.domain.notification.service.NotificationCommandService;
 import umc.duckmelang.domain.notification.service.NotificationQueryService;
 import umc.duckmelang.global.annotations.CommonApiResponses;
 import umc.duckmelang.global.apipayload.ApiResponse;
 import umc.duckmelang.global.security.user.CustomUserDetails;
+import umc.duckmelang.global.validation.annotation.ExistNotification;
 
 import java.util.List;
 
@@ -22,6 +24,7 @@ import java.util.List;
 @Validated
 public class NotificationController {
     private final NotificationQueryService notificationQueryService;
+    private final NotificationCommandService notificationCommandService;
 
     @Operation(summary = "알림 목록 조회 API", description = "지금까지의 모든 알림 내역을 보여줍니다. extraData는 postImage 또는 memberProfileImage을 반환합니다. postImage -> BOOKMARK일때, memberProfileImage -> MATE, REQUEST, REVIEW 일때.")
     @GetMapping("")
@@ -38,5 +41,13 @@ public class NotificationController {
     public SseEmitter getRealtimeNotification (@RequestHeader(value = "Last-Event-ID", required = false, defaultValue = "") String lastEventId, @AuthenticationPrincipal CustomUserDetails userDetails) {
         Long memberId = userDetails.getMemberId();
         return notificationQueryService.subscribe(memberId, lastEventId);
+    }
+
+    @Operation(summary = "알림 읽음 API", description = "알림의 isRead 속성을 false에서 true로 변경합니다")
+    @PatchMapping(value = "/{notificationId}/read")
+    @CommonApiResponses
+    public ApiResponse<NotificationResponseDto.NotificationReadDto> fetchNotificationRead (@ExistNotification @PathVariable Long notificationId) {
+        Notification notification = notificationCommandService.patchNotificationRead(notificationId);
+        return ApiResponse.onSuccess(NotificationConverter.notificationReadDto(notification));
     }
 }

--- a/src/main/java/umc/duckmelang/domain/notification/controller/NotificationController.java
+++ b/src/main/java/umc/duckmelang/domain/notification/controller/NotificationController.java
@@ -2,6 +2,7 @@ package umc.duckmelang.domain.notification.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
@@ -49,5 +50,13 @@ public class NotificationController {
     public ApiResponse<NotificationResponseDto.NotificationReadDto> fetchNotificationRead (@ExistNotification @PathVariable Long notificationId) {
         Notification notification = notificationCommandService.patchNotificationRead(notificationId);
         return ApiResponse.onSuccess(NotificationConverter.notificationReadDto(notification));
+    }
+
+    @Operation(summary = "알림 삭제 API", description = "알림을 삭제합니다. 204가 뜨면 성공입니다. 현재 피그마엔 없지만 알림 목록 조회에서 있으면 좋을 것 같아 만들었습니다.")
+    @DeleteMapping(value = "/{notificationId}")
+    @CommonApiResponses
+    public ResponseEntity<Void> deleteNotification (@ExistNotification @PathVariable Long notificationId) {
+        notificationCommandService.deleteNotification(notificationId);
+        return ResponseEntity.noContent().build(); // 204 No Content 반환
     }
 }

--- a/src/main/java/umc/duckmelang/domain/notification/controller/NotificationRestController.java
+++ b/src/main/java/umc/duckmelang/domain/notification/controller/NotificationRestController.java
@@ -23,7 +23,7 @@ import java.util.List;
 @RequestMapping("/notifications")
 @RequiredArgsConstructor
 @Validated
-public class NotificationController {
+public class NotificationRestController {
     private final NotificationQueryService notificationQueryService;
     private final NotificationCommandService notificationCommandService;
 

--- a/src/main/java/umc/duckmelang/domain/notification/controller/NotificationRestController.java
+++ b/src/main/java/umc/duckmelang/domain/notification/controller/NotificationRestController.java
@@ -31,7 +31,7 @@ public class NotificationRestController {
     @GetMapping("")
     @CommonApiResponses
     public ApiResponse<NotificationResponseDto.NotificationListDto> getNotificationList (@AuthenticationPrincipal CustomUserDetails userDetails){
-        Long memberId = userDetails.getMemberId();;
+        Long memberId = userDetails.getMemberId();
         List<Notification> NotificationList = notificationQueryService.getNotificationList(memberId);
         return ApiResponse.onSuccess(NotificationConverter.notificationListDto(NotificationList));
     }

--- a/src/main/java/umc/duckmelang/domain/notification/converter/NotificationConverter.java
+++ b/src/main/java/umc/duckmelang/domain/notification/converter/NotificationConverter.java
@@ -45,5 +45,13 @@ public class NotificationConverter {
                 .build();
     }
 
+    public static NotificationResponseDto.NotificationReadDto notificationReadDto(Notification notification) {
+        return NotificationResponseDto.NotificationReadDto.builder()
+                .id(notification.getId())
+                .content(notification.getContent())
+                .isRead(notification.getIsRead())
+                .build();
+    }
+
 
 }

--- a/src/main/java/umc/duckmelang/domain/notification/domain/Notification.java
+++ b/src/main/java/umc/duckmelang/domain/notification/domain/Notification.java
@@ -28,11 +28,11 @@ public class Notification extends BaseEntity {
     @Column(nullable = false)
     private NotificationType notificationType;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "sender_id", nullable = false)
     private Member sender;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "receiver_id", nullable = false)
     private Member receiver;
 

--- a/src/main/java/umc/duckmelang/domain/notification/domain/Notification.java
+++ b/src/main/java/umc/duckmelang/domain/notification/domain/Notification.java
@@ -38,5 +38,10 @@ public class Notification extends BaseEntity {
 
     //postImage, memberProfileImage 등
     private String extraData;
+
+//    알림 읽음
+    public void notificationReadTrue() {
+        this.isRead = true;
+    }
 }
 

--- a/src/main/java/umc/duckmelang/domain/notification/dto/NotificationResponseDto.java
+++ b/src/main/java/umc/duckmelang/domain/notification/dto/NotificationResponseDto.java
@@ -35,5 +35,15 @@ public class NotificationResponseDto {
 
     }
 
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class NotificationReadDto{
+        private Long id;
+        private String content;
+        private Boolean isRead;
+    }
+
 
 }

--- a/src/main/java/umc/duckmelang/domain/notification/service/NotificationCommandService.java
+++ b/src/main/java/umc/duckmelang/domain/notification/service/NotificationCommandService.java
@@ -12,4 +12,5 @@ public interface NotificationCommandService {
     void send(Member sender, Member receiver, NotificationType notificationType, String content, String extraData);
     void sendNotification(SseEmitter emitter, String eventId, String emitterId, Object data);
     Notification patchNotificationRead(Long notificationId);
+    void deleteNotification(Long notificationId);
 }

--- a/src/main/java/umc/duckmelang/domain/notification/service/NotificationCommandService.java
+++ b/src/main/java/umc/duckmelang/domain/notification/service/NotificationCommandService.java
@@ -2,6 +2,7 @@ package umc.duckmelang.domain.notification.service;
 
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 import umc.duckmelang.domain.member.domain.Member;
+import umc.duckmelang.domain.notification.domain.Notification;
 import umc.duckmelang.domain.notification.domain.enums.NotificationType;
 
 import java.util.Map;
@@ -10,4 +11,5 @@ public interface NotificationCommandService {
     void sendLostData(String lastEventId, Long memberId, String emitterId, SseEmitter emitter);
     void send(Member sender, Member receiver, NotificationType notificationType, String content, String extraData);
     void sendNotification(SseEmitter emitter, String eventId, String emitterId, Object data);
+    Notification patchNotificationRead(Long notificationId);
 }

--- a/src/main/java/umc/duckmelang/domain/notification/service/NotificationCommandServiceImpl.java
+++ b/src/main/java/umc/duckmelang/domain/notification/service/NotificationCommandServiceImpl.java
@@ -17,6 +17,10 @@ import java.util.Map;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import umc.duckmelang.domain.post.domain.Post;
+import umc.duckmelang.global.apipayload.code.status.ErrorStatus;
+import umc.duckmelang.global.apipayload.exception.NotificationException;
+import umc.duckmelang.global.apipayload.exception.PostException;
 
 
 @Service
@@ -63,5 +67,15 @@ public class NotificationCommandServiceImpl implements NotificationCommandServic
             logger.error("SSE 전송 실패: ", exception);
             emitterRepository.deleteById(emitterId);
         }
+    }
+
+    @Override
+    public Notification patchNotificationRead(Long notificationId) {
+        Notification notification = notificationRepository.findById(notificationId)
+                .orElseThrow(() -> new NotificationException(ErrorStatus.NOTIFICATION_NOT_FOUND));
+
+        notification.notificationReadTrue();
+
+        return notificationRepository.save(notification);
     }
 }

--- a/src/main/java/umc/duckmelang/domain/notification/service/NotificationCommandServiceImpl.java
+++ b/src/main/java/umc/duckmelang/domain/notification/service/NotificationCommandServiceImpl.java
@@ -17,10 +17,8 @@ import java.util.Map;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import umc.duckmelang.domain.post.domain.Post;
 import umc.duckmelang.global.apipayload.code.status.ErrorStatus;
 import umc.duckmelang.global.apipayload.exception.NotificationException;
-import umc.duckmelang.global.apipayload.exception.PostException;
 
 
 @Service
@@ -77,5 +75,13 @@ public class NotificationCommandServiceImpl implements NotificationCommandServic
         notification.notificationReadTrue();
 
         return notificationRepository.save(notification);
+    }
+
+    @Override
+    public void deleteNotification(Long notificationId) {
+        Notification notification = notificationRepository.findById(notificationId)
+                .orElseThrow(() -> new NotificationException(ErrorStatus.NOTIFICATION_NOT_FOUND));
+
+        notificationRepository.delete(notification);
     }
 }

--- a/src/main/java/umc/duckmelang/domain/notification/service/NotificationQueryService.java
+++ b/src/main/java/umc/duckmelang/domain/notification/service/NotificationQueryService.java
@@ -12,4 +12,5 @@ public interface NotificationQueryService {
     String makeTimeIncludeId(Long memberId);
     boolean hasLostData(String lastEventId);
     boolean existsById(Long notificationId);
+
 }

--- a/src/main/java/umc/duckmelang/domain/notification/service/NotificationQueryService.java
+++ b/src/main/java/umc/duckmelang/domain/notification/service/NotificationQueryService.java
@@ -4,10 +4,12 @@ import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 import umc.duckmelang.domain.notification.domain.Notification;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface NotificationQueryService {
     List<Notification> getNotificationList(Long memberId);
     SseEmitter subscribe(Long memberId, String lastEventId);
     String makeTimeIncludeId(Long memberId);
     boolean hasLostData(String lastEventId);
+    boolean existsById(Long notificationId);
 }

--- a/src/main/java/umc/duckmelang/domain/notification/service/NotificationQueryServiceImpl.java
+++ b/src/main/java/umc/duckmelang/domain/notification/service/NotificationQueryServiceImpl.java
@@ -10,6 +10,7 @@ import umc.duckmelang.domain.notification.repository.EmitterRepository;
 import umc.duckmelang.domain.notification.repository.NotificationRepository;
 
 import java.util.List;
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -54,6 +55,11 @@ public class NotificationQueryServiceImpl implements NotificationQueryService {
     @Override
     public boolean hasLostData(String lastEventId) { // (5)
         return lastEventId != null && !lastEventId.isEmpty();
+    }
+
+    @Override
+    public boolean existsById(Long notificationId) {
+        return notificationRepository.existsById(notificationId);
     }
 
 }

--- a/src/main/java/umc/duckmelang/domain/notification/service/NotificationQueryServiceImpl.java
+++ b/src/main/java/umc/duckmelang/domain/notification/service/NotificationQueryServiceImpl.java
@@ -8,9 +8,10 @@ import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 import umc.duckmelang.domain.notification.domain.Notification;
 import umc.duckmelang.domain.notification.repository.EmitterRepository;
 import umc.duckmelang.domain.notification.repository.NotificationRepository;
+import umc.duckmelang.global.apipayload.code.status.ErrorStatus;
+import umc.duckmelang.global.apipayload.exception.NotificationException;
 
 import java.util.List;
-import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -61,5 +62,7 @@ public class NotificationQueryServiceImpl implements NotificationQueryService {
     public boolean existsById(Long notificationId) {
         return notificationRepository.existsById(notificationId);
     }
+
+
 
 }

--- a/src/main/java/umc/duckmelang/domain/notificationsetting/controller/NotificationSettingRestController.java
+++ b/src/main/java/umc/duckmelang/domain/notificationsetting/controller/NotificationSettingRestController.java
@@ -1,0 +1,4 @@
+package umc.duckmelang.domain.notificationsetting.controller;
+
+public class NotificationSettingRestController {
+}

--- a/src/main/java/umc/duckmelang/domain/notificationsetting/controller/NotificationSettingRestController.java
+++ b/src/main/java/umc/duckmelang/domain/notificationsetting/controller/NotificationSettingRestController.java
@@ -1,4 +1,32 @@
 package umc.duckmelang.domain.notificationsetting.controller;
 
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import umc.duckmelang.domain.notificationsetting.converter.NotificationSettingConverter;
+import umc.duckmelang.domain.notificationsetting.domain.NotificationSetting;
+import umc.duckmelang.domain.notificationsetting.dto.NotificationSettingResponseDto;
+import umc.duckmelang.domain.notificationsetting.service.NotificationSettingQueryService;
+import umc.duckmelang.global.annotations.CommonApiResponses;
+import umc.duckmelang.global.apipayload.ApiResponse;
+import umc.duckmelang.global.security.user.CustomUserDetails;
+
+@RestController
+@RequestMapping("/notifications/setting")
+@RequiredArgsConstructor
 public class NotificationSettingRestController {
+    private final NotificationSettingQueryService notificationSettingQueryService;
+
+    @Operation(summary = "알림 설정 조회 API", description = "해당하는 멤버의 알림 설정을 조회합니다.")
+    @GetMapping("")
+    @CommonApiResponses
+    public ApiResponse<NotificationSettingResponseDto.NotificationSettingDto> getNotificationSetting(@AuthenticationPrincipal CustomUserDetails userDetails){
+        Long memberId = userDetails.getMemberId();
+        NotificationSetting notificationSetting = notificationSettingQueryService.findNotificationSetting(memberId);
+        return ApiResponse.onSuccess(NotificationSettingConverter.notificationSettingDto(notificationSetting));
+
+    }
 }

--- a/src/main/java/umc/duckmelang/domain/notificationsetting/controller/NotificationSettingRestController.java
+++ b/src/main/java/umc/duckmelang/domain/notificationsetting/controller/NotificationSettingRestController.java
@@ -3,22 +3,26 @@ package umc.duckmelang.domain.notificationsetting.controller;
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 import umc.duckmelang.domain.notificationsetting.converter.NotificationSettingConverter;
 import umc.duckmelang.domain.notificationsetting.domain.NotificationSetting;
+import umc.duckmelang.domain.notificationsetting.dto.NotificationSettingRequestDto;
 import umc.duckmelang.domain.notificationsetting.dto.NotificationSettingResponseDto;
+import umc.duckmelang.domain.notificationsetting.service.NotificationSettingCommandService;
 import umc.duckmelang.domain.notificationsetting.service.NotificationSettingQueryService;
+import umc.duckmelang.domain.post.dto.PostRequestDto;
 import umc.duckmelang.global.annotations.CommonApiResponses;
 import umc.duckmelang.global.apipayload.ApiResponse;
 import umc.duckmelang.global.security.user.CustomUserDetails;
+
+import java.util.Map;
 
 @RestController
 @RequestMapping("/notifications/setting")
 @RequiredArgsConstructor
 public class NotificationSettingRestController {
     private final NotificationSettingQueryService notificationSettingQueryService;
+    private final NotificationSettingCommandService notificationSettingCommandService;
 
     @Operation(summary = "알림 설정 조회 API", description = "해당하는 멤버의 알림 설정을 조회합니다.")
     @GetMapping("")
@@ -27,6 +31,15 @@ public class NotificationSettingRestController {
         Long memberId = userDetails.getMemberId();
         NotificationSetting notificationSetting = notificationSettingQueryService.findNotificationSetting(memberId);
         return ApiResponse.onSuccess(NotificationSettingConverter.notificationSettingDto(notificationSetting));
+    }
 
+    @Operation(summary = "알림 설정 관리 API", description = "알림 설정을 변경합니다. 변경하지 않는 부분은 지우고, 변경할 부분만 써주세요(true/false 형식)")
+    @PatchMapping("")
+    @CommonApiResponses
+    public ApiResponse<NotificationSettingResponseDto.NotificationSettingDto> patchNotificationSetting(@AuthenticationPrincipal CustomUserDetails userDetails, @RequestBody NotificationSettingRequestDto.UpdateNotificationSettingRequestDto request){
+        Long memberId = userDetails.getMemberId();
+        notificationSettingCommandService.updateNotificationSetting(memberId, request);
+        NotificationSetting notificationSetting = notificationSettingQueryService.findNotificationSetting(memberId);
+        return ApiResponse.onSuccess(NotificationSettingConverter.notificationSettingDto(notificationSetting));
     }
 }

--- a/src/main/java/umc/duckmelang/domain/notificationsetting/converter/NotificationSettingConverter.java
+++ b/src/main/java/umc/duckmelang/domain/notificationsetting/converter/NotificationSettingConverter.java
@@ -3,6 +3,7 @@ package umc.duckmelang.domain.notificationsetting.converter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import umc.duckmelang.domain.notificationsetting.domain.NotificationSetting;
+import umc.duckmelang.domain.notificationsetting.dto.NotificationSettingRequestDto;
 import umc.duckmelang.domain.notificationsetting.dto.NotificationSettingResponseDto;
 
 @Component
@@ -17,5 +18,16 @@ public class NotificationSettingConverter {
                 .reviewNotificationEnabled(notificationSetting.getReviewNotificationEnabled())
                 .bookmarkNotificationEnabled(notificationSetting.getBookmarkNotificationEnabled())
                 .build();
+    }
+
+    public static NotificationSetting updateNotificationSetting(NotificationSettingRequestDto.UpdateNotificationSettingRequestDto request) {
+        NotificationSetting notificationSetting = NotificationSetting.builder()
+                .chatNotificationEnabled(request.getChatNotificationEnabled())
+                .requestNotificationEnabled(request.getRequestNotificationEnabled())
+                .reviewNotificationEnabled(request.getReviewNotificationEnabled())
+                .bookmarkNotificationEnabled(request.getBookmarkNotificationEnabled())
+                .build();
+
+        return notificationSetting;
     }
 }

--- a/src/main/java/umc/duckmelang/domain/notificationsetting/converter/NotificationSettingConverter.java
+++ b/src/main/java/umc/duckmelang/domain/notificationsetting/converter/NotificationSettingConverter.java
@@ -1,4 +1,21 @@
 package umc.duckmelang.domain.notificationsetting.converter;
 
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import umc.duckmelang.domain.notificationsetting.domain.NotificationSetting;
+import umc.duckmelang.domain.notificationsetting.dto.NotificationSettingResponseDto;
+
+@Component
+@RequiredArgsConstructor
 public class NotificationSettingConverter {
+    public static NotificationSettingResponseDto.NotificationSettingDto notificationSettingDto(NotificationSetting notificationSetting) {
+        return NotificationSettingResponseDto.NotificationSettingDto.builder()
+                .notificationSettingId(notificationSetting.getId())
+                .memberId(notificationSetting.getMember().getId())
+                .chatNotificationEnabled(notificationSetting.getChatNotificationEnabled())
+                .requestNotificationEnabled(notificationSetting.getRequestNotificationEnabled())
+                .reviewNotificationEnabled(notificationSetting.getReviewNotificationEnabled())
+                .bookmarkNotificationEnabled(notificationSetting.getBookmarkNotificationEnabled())
+                .build();
+    }
 }

--- a/src/main/java/umc/duckmelang/domain/notificationsetting/converter/NotificationSettingConverter.java
+++ b/src/main/java/umc/duckmelang/domain/notificationsetting/converter/NotificationSettingConverter.java
@@ -1,0 +1,4 @@
+package umc.duckmelang.domain.notificationsetting.converter;
+
+public class NotificationSettingConverter {
+}

--- a/src/main/java/umc/duckmelang/domain/notificationsetting/domain/NotificationSetting.java
+++ b/src/main/java/umc/duckmelang/domain/notificationsetting/domain/NotificationSetting.java
@@ -21,13 +21,22 @@ public class NotificationSetting extends BaseEntity {
     @JoinColumn(name = "member_id", unique = true, nullable = false)
     private Member member;
 
+    @Setter
     @Column(nullable = false)
     private Boolean chatNotificationEnabled = true;  // 채팅 알림 수신 여부
+
+    @Setter
     @Column(nullable = false)
     private Boolean requestNotificationEnabled = true;  // 동행 확정 요청 알림 수신 여부
+
+    @Setter
     @Column(nullable = false)
     private Boolean reviewNotificationEnabled = true;  // 후기 작성 알림 수신 여부
+
+    @Setter
     @Column(nullable = false)
     private Boolean bookmarkNotificationEnabled = true; //내 게시글 북마크 알림 수신 여부
+
+
 
 }

--- a/src/main/java/umc/duckmelang/domain/notificationsetting/domain/NotificationSetting.java
+++ b/src/main/java/umc/duckmelang/domain/notificationsetting/domain/NotificationSetting.java
@@ -27,4 +27,7 @@ public class NotificationSetting extends BaseEntity {
     private Boolean requestNotificationEnabled = true;  // 동행 확정 요청 알림 수신 여부
     @Column(nullable = false)
     private Boolean reviewNotificationEnabled = true;  // 후기 작성 알림 수신 여부
+    @Column(nullable = false)
+    private Boolean bookmarkNotificationEnabled = true; //내 게시글 북마크 알림 수신 여부
+
 }

--- a/src/main/java/umc/duckmelang/domain/notificationsetting/domain/NotificationSetting.java
+++ b/src/main/java/umc/duckmelang/domain/notificationsetting/domain/NotificationSetting.java
@@ -17,7 +17,7 @@ public class NotificationSetting extends BaseEntity {
     @Column(name = "notification_setting_id", nullable = false)
     private Long id;
 
-    @OneToOne
+    @OneToOne(cascade = CascadeType.PERSIST)  // PERSIST 추가
     @JoinColumn(name = "member_id", unique = true, nullable = false)
     private Member member;
 

--- a/src/main/java/umc/duckmelang/domain/notificationsetting/dto/NotificationSettingRequestDto.java
+++ b/src/main/java/umc/duckmelang/domain/notificationsetting/dto/NotificationSettingRequestDto.java
@@ -1,0 +1,19 @@
+package umc.duckmelang.domain.notificationsetting.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+public class NotificationSettingRequestDto {
+
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    public static class UpdateNotificationSettingRequestDto{
+        private Boolean chatNotificationEnabled;
+        private Boolean requestNotificationEnabled;
+        private Boolean reviewNotificationEnabled;
+        private Boolean bookmarkNotificationEnabled;
+    }
+
+}

--- a/src/main/java/umc/duckmelang/domain/notificationsetting/dto/NotificationSettingResponseDto.java
+++ b/src/main/java/umc/duckmelang/domain/notificationsetting/dto/NotificationSettingResponseDto.java
@@ -1,0 +1,4 @@
+package umc.duckmelang.domain.notificationsetting.dto;
+
+public class NotificationSettingResponseDto {
+}

--- a/src/main/java/umc/duckmelang/domain/notificationsetting/dto/NotificationSettingResponseDto.java
+++ b/src/main/java/umc/duckmelang/domain/notificationsetting/dto/NotificationSettingResponseDto.java
@@ -1,4 +1,27 @@
 package umc.duckmelang.domain.notificationsetting.dto;
 
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import umc.duckmelang.domain.notification.domain.enums.NotificationType;
+
+import java.time.LocalDateTime;
+
 public class NotificationSettingResponseDto {
+
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class NotificationSettingDto {
+        private Long notificationSettingId;
+        private Long memberId;
+        private Boolean chatNotificationEnabled;
+        private Boolean requestNotificationEnabled;
+        private Boolean reviewNotificationEnabled;
+        private Boolean bookmarkNotificationEnabled;
+
+    }
+
 }

--- a/src/main/java/umc/duckmelang/domain/notificationsetting/repository/NotificationSettingRepository.java
+++ b/src/main/java/umc/duckmelang/domain/notificationsetting/repository/NotificationSettingRepository.java
@@ -1,0 +1,9 @@
+package umc.duckmelang.domain.notificationsetting.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import umc.duckmelang.domain.notificationsetting.domain.NotificationSetting;
+
+@Repository
+public interface NotificationSettingRepository extends JpaRepository<NotificationSetting, Long> {
+}

--- a/src/main/java/umc/duckmelang/domain/notificationsetting/repository/NotificationSettingRepository.java
+++ b/src/main/java/umc/duckmelang/domain/notificationsetting/repository/NotificationSettingRepository.java
@@ -1,9 +1,15 @@
 package umc.duckmelang.domain.notificationsetting.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 import umc.duckmelang.domain.notificationsetting.domain.NotificationSetting;
 
+import java.util.Optional;
+
 @Repository
 public interface NotificationSettingRepository extends JpaRepository<NotificationSetting, Long> {
+
+    @Query("SELECT n from NotificationSetting n JOIN FETCH n.member m where m.id = :memberId")
+    Optional<NotificationSetting> findByMemberId(Long memberId);
 }

--- a/src/main/java/umc/duckmelang/domain/notificationsetting/service/NotificationSettingCommandService.java
+++ b/src/main/java/umc/duckmelang/domain/notificationsetting/service/NotificationSettingCommandService.java
@@ -1,0 +1,4 @@
+package umc.duckmelang.domain.notificationsetting.service;
+
+public interface NotificationSettingCommandService {
+}

--- a/src/main/java/umc/duckmelang/domain/notificationsetting/service/NotificationSettingCommandService.java
+++ b/src/main/java/umc/duckmelang/domain/notificationsetting/service/NotificationSettingCommandService.java
@@ -1,4 +1,10 @@
 package umc.duckmelang.domain.notificationsetting.service;
 
+import umc.duckmelang.domain.notificationsetting.domain.NotificationSetting;
+import umc.duckmelang.domain.notificationsetting.dto.NotificationSettingRequestDto;
+
+import java.util.Map;
+
 public interface NotificationSettingCommandService {
+    void updateNotificationSetting(Long memberId, NotificationSettingRequestDto.UpdateNotificationSettingRequestDto request);
 }

--- a/src/main/java/umc/duckmelang/domain/notificationsetting/service/NotificationSettingCommandServiceImpl.java
+++ b/src/main/java/umc/duckmelang/domain/notificationsetting/service/NotificationSettingCommandServiceImpl.java
@@ -3,9 +3,37 @@ package umc.duckmelang.domain.notificationsetting.service;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import umc.duckmelang.domain.notificationsetting.domain.NotificationSetting;
+import umc.duckmelang.domain.notificationsetting.dto.NotificationSettingRequestDto;
+import umc.duckmelang.domain.notificationsetting.repository.NotificationSettingRepository;
+import umc.duckmelang.global.apipayload.code.status.ErrorStatus;
+import umc.duckmelang.global.apipayload.exception.NotificationSettingException;
+
+import java.util.Map;
 
 @Service
 @RequiredArgsConstructor
 @Transactional
 public class NotificationSettingCommandServiceImpl implements NotificationSettingCommandService {
+    public final NotificationSettingRepository notificationSettingRepository;
+
+    @Override
+    public void updateNotificationSetting(Long memberId, NotificationSettingRequestDto.UpdateNotificationSettingRequestDto request) {
+        NotificationSetting setting = notificationSettingRepository.findByMemberId(memberId)
+                .orElseThrow(() -> new NotificationSettingException(ErrorStatus.NOTIFICATION_SETTING_NOT_FOUND));
+
+        if (request.getChatNotificationEnabled() != null) {
+            setting.setChatNotificationEnabled(request.getChatNotificationEnabled());
+        }
+        if (request.getRequestNotificationEnabled() != null) {
+            setting.setRequestNotificationEnabled(request.getRequestNotificationEnabled());
+        }
+        if (request.getReviewNotificationEnabled() != null) {
+            setting.setReviewNotificationEnabled(request.getReviewNotificationEnabled());
+        }
+        if (request.getBookmarkNotificationEnabled() != null) {
+            setting.setBookmarkNotificationEnabled(request.getBookmarkNotificationEnabled());
+        }
+
+    }
 }

--- a/src/main/java/umc/duckmelang/domain/notificationsetting/service/NotificationSettingCommandServiceImpl.java
+++ b/src/main/java/umc/duckmelang/domain/notificationsetting/service/NotificationSettingCommandServiceImpl.java
@@ -1,0 +1,11 @@
+package umc.duckmelang.domain.notificationsetting.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class NotificationSettingCommandServiceImpl implements NotificationSettingCommandService {
+}

--- a/src/main/java/umc/duckmelang/domain/notificationsetting/service/NotificationSettingQueryService.java
+++ b/src/main/java/umc/duckmelang/domain/notificationsetting/service/NotificationSettingQueryService.java
@@ -1,4 +1,7 @@
 package umc.duckmelang.domain.notificationsetting.service;
 
+import umc.duckmelang.domain.notificationsetting.domain.NotificationSetting;
+
 public interface NotificationSettingQueryService {
+    NotificationSetting findNotificationSetting(Long memberId);
 }

--- a/src/main/java/umc/duckmelang/domain/notificationsetting/service/NotificationSettingQueryService.java
+++ b/src/main/java/umc/duckmelang/domain/notificationsetting/service/NotificationSettingQueryService.java
@@ -1,0 +1,4 @@
+package umc.duckmelang.domain.notificationsetting.service;
+
+public interface NotificationSettingQueryService {
+}

--- a/src/main/java/umc/duckmelang/domain/notificationsetting/service/NotificationSettingQueryServiceImpl.java
+++ b/src/main/java/umc/duckmelang/domain/notificationsetting/service/NotificationSettingQueryServiceImpl.java
@@ -1,0 +1,11 @@
+package umc.duckmelang.domain.notificationsetting.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class NotificationSettingQueryServiceImpl implements NotificationSettingQueryService {
+}

--- a/src/main/java/umc/duckmelang/domain/notificationsetting/service/NotificationSettingQueryServiceImpl.java
+++ b/src/main/java/umc/duckmelang/domain/notificationsetting/service/NotificationSettingQueryServiceImpl.java
@@ -3,9 +3,21 @@ package umc.duckmelang.domain.notificationsetting.service;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import umc.duckmelang.domain.notificationsetting.domain.NotificationSetting;
+import umc.duckmelang.domain.notificationsetting.repository.NotificationSettingRepository;
+import umc.duckmelang.global.apipayload.code.status.ErrorStatus;
+import umc.duckmelang.global.apipayload.exception.NotificationSettingException;
 
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class NotificationSettingQueryServiceImpl implements NotificationSettingQueryService {
+    private final NotificationSettingRepository notificationSettingRepository;
+
+    @Override
+    public NotificationSetting findNotificationSetting(Long memberId){
+        return notificationSettingRepository.findByMemberId(memberId)
+                .orElseThrow(() -> new NotificationSettingException(ErrorStatus.NOTIFICATION_SETTING_NOT_FOUND));
+
+    }
 }

--- a/src/main/java/umc/duckmelang/domain/review/service/ReviewCommandServiceImpl.java
+++ b/src/main/java/umc/duckmelang/domain/review/service/ReviewCommandServiceImpl.java
@@ -10,6 +10,8 @@ import umc.duckmelang.domain.member.repository.MemberRepository;
 import umc.duckmelang.domain.memberprofileimage.domain.MemberProfileImage;
 import umc.duckmelang.domain.memberprofileimage.service.MemberProfileImageQueryService;
 import umc.duckmelang.domain.notification.service.NotificationCommandService;
+import umc.duckmelang.domain.notificationsetting.domain.NotificationSetting;
+import umc.duckmelang.domain.notificationsetting.service.NotificationSettingQueryService;
 import umc.duckmelang.domain.review.converter.ReviewConverter;
 import umc.duckmelang.domain.review.domain.Review;
 import umc.duckmelang.domain.review.dto.ReviewRequestDto;
@@ -32,6 +34,7 @@ public class ReviewCommandServiceImpl implements ReviewCommandService {
     private final ApplicationRepository applicationRepository;
     //자신에 대한 후기가 남겨졌을 때 알림
     private final NotificationCommandService notificationCommandService;
+    private final NotificationSettingQueryService notificationSettingQueryService;
     private final MemberProfileImageQueryService memberProfileImageQueryService;
 
     @Override
@@ -48,7 +51,11 @@ public class ReviewCommandServiceImpl implements ReviewCommandService {
                 .orElseThrow(() -> new MemberProfileImageException(ErrorStatus.MEMBER_PROFILE_IMAGE_NOT_FOUND));
 
         Review review = ReviewConverter.toReview(request, sender, receiver,application);
-        notificationCommandService.send(sender, receiver,REVIEW,sender.getNickname() + " 님이 후기를 작성했어요", profileImageUrl);
+//        review 알림 켜져있을때만 전송
+        NotificationSetting notificationSetting = notificationSettingQueryService.findNotificationSetting(receiver.getId());
+        if (notificationSetting.getReviewNotificationEnabled()) {
+            notificationCommandService.send(sender, receiver, REVIEW, sender.getNickname() + " 님이 후기를 작성했어요", profileImageUrl);
+        }
         return reviewRepository.save(review);
     }
 }

--- a/src/main/java/umc/duckmelang/global/apipayload/code/status/ErrorStatus.java
+++ b/src/main/java/umc/duckmelang/global/apipayload/code/status/ErrorStatus.java
@@ -67,7 +67,10 @@ public enum ErrorStatus implements BaseErrorCode {
     JSON_CONVERSION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "WEBSOCKET5001", "JSON 변환에 실패했습니다."),
 
     //알림 관련 에러
-    NOTIFICATION_NOT_FOUND(HttpStatus.NOT_FOUND, "NOTIFICATION4001", "해당하는 알림이 없습니다");
+    NOTIFICATION_NOT_FOUND(HttpStatus.NOT_FOUND, "NOTIFICATION4001", "해당하는 알림이 없습니다"),
+
+    //알림 설정 관련 에러
+    NOTIFICATION_SETTING_NOT_FOUND(HttpStatus.NOT_FOUND, "NOTIFICATION_SETTING4001", "해당하는 알림 설정이 없습니다");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/umc/duckmelang/global/apipayload/code/status/ErrorStatus.java
+++ b/src/main/java/umc/duckmelang/global/apipayload/code/status/ErrorStatus.java
@@ -64,7 +64,10 @@ public enum ErrorStatus implements BaseErrorCode {
     // 채팅 통신 관련 에러
     JSON_PROCESSING_ERROR(HttpStatus.BAD_REQUEST, "WEBSOCKET4001", "메시지 변환 중 매핑 오류가 발생했습니다."),
     INVALID_JSON_FORMAT(HttpStatus.BAD_REQUEST, "WEBSOCKET4002", "유효하지 않은 JSON 형식입니다."),
-    JSON_CONVERSION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "WEBSOCKET5001", "JSON 변환에 실패했습니다.");
+    JSON_CONVERSION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "WEBSOCKET5001", "JSON 변환에 실패했습니다."),
+
+    //알림 관련 에러
+    NOTIFICATION_NOT_FOUND(HttpStatus.NOT_FOUND, "NOTIFICATION4001", "해당하는 알림이 없습니다");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/umc/duckmelang/global/apipayload/exception/NotificationException.java
+++ b/src/main/java/umc/duckmelang/global/apipayload/exception/NotificationException.java
@@ -1,0 +1,9 @@
+package umc.duckmelang.global.apipayload.exception;
+
+import umc.duckmelang.global.apipayload.code.BaseErrorCode;
+
+public class NotificationException extends GeneralException {
+    public NotificationException(BaseErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/umc/duckmelang/global/apipayload/exception/NotificationSettingException.java
+++ b/src/main/java/umc/duckmelang/global/apipayload/exception/NotificationSettingException.java
@@ -1,0 +1,9 @@
+package umc.duckmelang.global.apipayload.exception;
+
+import umc.duckmelang.global.apipayload.code.BaseErrorCode;
+
+public class NotificationSettingException extends GeneralException {
+    public NotificationSettingException(BaseErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/umc/duckmelang/global/validation/annotation/ExistNotification.java
+++ b/src/main/java/umc/duckmelang/global/validation/annotation/ExistNotification.java
@@ -1,0 +1,19 @@
+package umc.duckmelang.global.validation.annotation;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+import umc.duckmelang.global.validation.validator.IdolExistValidator;
+import umc.duckmelang.global.validation.validator.NotificationExistValidator;
+
+import java.lang.annotation.*;
+
+@Documented
+@Constraint(validatedBy = NotificationExistValidator.class)
+@Target( { ElementType.METHOD, ElementType.FIELD, ElementType.PARAMETER })
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ExistNotification {
+
+    String message() default "해당하는 알림이 존재하지 않습니다";
+    Class<?>[] groups() default {};
+    Class<? extends Payload>[] payload() default {};
+}

--- a/src/main/java/umc/duckmelang/global/validation/validator/NotificationExistValidator.java
+++ b/src/main/java/umc/duckmelang/global/validation/validator/NotificationExistValidator.java
@@ -1,0 +1,39 @@
+package umc.duckmelang.global.validation.validator;
+
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import umc.duckmelang.domain.idolcategory.domain.IdolCategory;
+import umc.duckmelang.domain.notification.domain.Notification;
+import umc.duckmelang.domain.notification.service.NotificationQueryService;
+import umc.duckmelang.domain.post.domain.Post;
+import umc.duckmelang.global.apipayload.code.status.ErrorStatus;
+import umc.duckmelang.global.validation.annotation.ExistNotification;
+import umc.duckmelang.global.validation.annotation.ExistsMember;
+
+import java.util.Optional;
+
+@Component
+@RequiredArgsConstructor
+public class NotificationExistValidator implements ConstraintValidator<ExistNotification, Long> {
+
+    private final NotificationQueryService notificationQueryService;
+
+    @Override
+    public void initialize(ExistNotification constraintAnnotation) {
+        ConstraintValidator.super.initialize(constraintAnnotation);
+    }
+
+    @Override
+    public boolean isValid(Long notificationId, ConstraintValidatorContext context) {
+        boolean exists = notificationQueryService.existsById(notificationId);
+
+        if (!exists) {
+            context.disableDefaultConstraintViolation();
+            context.buildConstraintViolationWithTemplate(ErrorStatus.NOTIFICATION_NOT_FOUND.toString()).addConstraintViolation();
+            return false;
+        }
+        return true;
+    }
+}


### PR DESCRIPTION
## 개요
알림 읽음 API, 알림 삭제 API
알림 설정 변경 API, 알림 설정 조회 API 구현
member가 생기면 바로 알림 설정이 생기게 하기 위해 @PostPersist 를 사용하려 했지만, 강제 주입 해야만 들어가 오히려 비효율적 -> 회원가입 API에서 수동 추가로 변경
선택한 알림의 enabled가 true일때만 알림이 전송되도록 로직 변경

## PR 유형
어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
