### PR TITLE
feature/#118 : 아이돌 전체 목록 조회 API 구현

### DIFF
--- a/src/main/java/umc/duckmelang/domain/idolcategory/controller/IdolCategoryRestController.java
+++ b/src/main/java/umc/duckmelang/domain/idolcategory/controller/IdolCategoryRestController.java
@@ -1,0 +1,31 @@
+package umc.duckmelang.domain.idolcategory.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import umc.duckmelang.domain.idolcategory.converter.IdolCategoryConverter;
+import umc.duckmelang.domain.idolcategory.domain.IdolCategory;
+import umc.duckmelang.domain.idolcategory.dto.IdolCategoryResponseDto;
+import umc.duckmelang.domain.idolcategory.service.IdolCategoryQueryService;
+import umc.duckmelang.global.annotations.CommonApiResponses;
+import umc.duckmelang.global.apipayload.ApiResponse;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/idols")
+@RequiredArgsConstructor
+public class IdolCategoryRestController {
+
+    private final IdolCategoryQueryService idolCategoryQueryService;
+
+    @GetMapping("")
+    @CommonApiResponses
+    @Operation(summary = "전체 아이돌 목록 조회 API", description = "전체 목록을 한번에 조회합니다. 추후 아이돌 수가 많아진다면 무한 스크롤 방식으로 수정하겠습니다!")
+    public ApiResponse<IdolCategoryResponseDto.IdolListDto> getAllIdolList() {
+        List<IdolCategory> idolCategoryList = idolCategoryQueryService.getAllIdolList();
+        return ApiResponse.onSuccess(IdolCategoryConverter.toIdolListDto(idolCategoryList));
+    }
+}

--- a/src/main/java/umc/duckmelang/domain/idolcategory/service/IdolCategoryQueryService.java
+++ b/src/main/java/umc/duckmelang/domain/idolcategory/service/IdolCategoryQueryService.java
@@ -8,4 +8,5 @@ import java.util.Optional;
 public interface IdolCategoryQueryService {
     Optional<IdolCategory> findIdolCategory(Long id);
     List<IdolCategory> getIdolListByKeyword(String keyword);
+    List<IdolCategory> getAllIdolList();
 }

--- a/src/main/java/umc/duckmelang/domain/idolcategory/service/IdolCategoryQueryServiceImpl.java
+++ b/src/main/java/umc/duckmelang/domain/idolcategory/service/IdolCategoryQueryServiceImpl.java
@@ -24,4 +24,9 @@ public class IdolCategoryQueryServiceImpl implements IdolCategoryQueryService {
     public List<IdolCategory> getIdolListByKeyword(String keyword){
         return idolCategoryRepository.findByKeyword(keyword);
     }
+
+    @Override
+    public List<IdolCategory> getAllIdolList(){
+        return idolCategoryRepository.findAll();
+    }
 }


### PR DESCRIPTION
## 개요
iOS 측에서 요청주셔 구현한 아이돌 전체 목록 조회 API입니다.
한 번에 모두 보내달라고 요청주셔서 모두 조회하는 방식으로 만들었는데, 아이돌 수가 많아진다면 무한 스크롤 방식으로 변경할 생각입니다!
로컬 swagger에서 잘 작동하는 것 확인했습니다.

## PR 유형
어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
