### PR TITLE
Feat: 검색기능에 필터링 설정 기능 구현

### DIFF
--- a/src/main/java/umc/duckmelang/domain/member/service/mypage/MyPageCommandServiceImpl.java
+++ b/src/main/java/umc/duckmelang/domain/member/service/mypage/MyPageCommandServiceImpl.java
@@ -22,7 +22,6 @@ import umc.duckmelang.global.security.user.CustomUserDetails;
 public class MyPageCommandServiceImpl implements MyPageCommandService{
     private final MemberRepository memberRepository;
     private final JwtUtil jwtUtil;
-    private final AuthRepository authRepository;
     private final BlacklistService blacklistService;
 
     @Override

--- a/src/main/java/umc/duckmelang/domain/post/controller/PostRestController.java
+++ b/src/main/java/umc/duckmelang/domain/post/controller/PostRestController.java
@@ -106,14 +106,17 @@ public class PostRestController {
     }
 
     @Operation(summary = "게시글 검색 API", description = "게시글 검색 API입니다. title 기준으로 검색합니다. " +
-            "사용자가 설정한 필터링 조건과 지뢰를 통해 게시글을 조회할 수 있도록 설정했습니다.")
+            "사용자가 기존에 설정한 필터링 조건이 아닌, 검색할 때마다 새로운 필터 값을 적용하여 조회합니다. 다만, 지뢰 필터링은 동일하게 적용되어있습니다." +
+            "필터 값(gender, minAge, maxAge)은 각각 선택적으로 적용되며, 요청 시 지정하지 않으면 전체 검색이 가능합니다.")
     @GetMapping("/search")
     @CommonApiResponses
     public ApiResponse<PostResponseDto.PostPreviewListDto> getPostListByTitle (@ValidPageNumber @RequestParam(name = "page",  defaultValue = "0") Integer page,
                                                                                @AuthenticationPrincipal CustomUserDetails userDetails,
-                                                                               @RequestParam(name="searchKeyword") String searchKeyword){
-        MemberFilterDto.FilterResponseDto userFilter = myPageQueryService.getMemberFilter(userDetails.getMemberId());
-        Page<Post> postList = postQueryService.getFilteredPostListByTitle(searchKeyword, userFilter.getGender(), userFilter.getMinAge(), userFilter.getMaxAge(), page, userDetails.getMemberId());
+                                                                               @RequestParam(name="searchKeyword") String searchKeyword,
+                                                                               @RequestParam(name="gender", required = false) Gender gender,
+                                                                               @RequestParam(name="minAge", required = false) Integer minAge,
+                                                                               @RequestParam(name="maxAge", required = false) Integer maxAge){
+        Page<Post> postList = postQueryService.getFilteredPostListByTitle(searchKeyword, gender, minAge, maxAge, page, userDetails.getMemberId());
         return ApiResponse.onSuccess(PostConverter.postPreviewListDto(postList));
     }
 

--- a/src/main/java/umc/duckmelang/domain/post/dto/PostRequestDto.java
+++ b/src/main/java/umc/duckmelang/domain/post/dto/PostRequestDto.java
@@ -3,9 +3,8 @@ package umc.duckmelang.domain.post.dto;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
+import lombok.*;
+import umc.duckmelang.domain.member.domain.enums.Gender;
 import umc.duckmelang.domain.postimage.dto.PostImageRequestDto;
 
 import java.time.LocalDate;
@@ -29,7 +28,5 @@ public class PostRequestDto {
         private LocalDate date;
         @Size(max = 5)
         private List<PostImageRequestDto.ImageMetadata> imageInfos;  // 이미지 메타데이터 리스트
-
-//        private List<String> postImageUrls;
     }
 }

--- a/src/main/java/umc/duckmelang/domain/post/service/PostCommandService.java
+++ b/src/main/java/umc/duckmelang/domain/post/service/PostCommandService.java
@@ -3,6 +3,8 @@ package umc.duckmelang.domain.post.service;
 import org.springframework.web.multipart.MultipartFile;
 import umc.duckmelang.domain.post.domain.Post;
 import umc.duckmelang.domain.post.dto.PostRequestDto;
+import umc.duckmelang.domain.post.dto.PostResponseDto;
+
 import java.util.*;
 
 public interface PostCommandService {

--- a/src/main/java/umc/duckmelang/domain/post/service/PostCommandServiceImpl.java
+++ b/src/main/java/umc/duckmelang/domain/post/service/PostCommandServiceImpl.java
@@ -14,6 +14,7 @@ import umc.duckmelang.domain.memberprofileimage.converter.MemberProfileImageConv
 import umc.duckmelang.domain.post.converter.PostConverter;
 import umc.duckmelang.domain.post.domain.Post;
 import umc.duckmelang.domain.post.dto.PostRequestDto;
+import umc.duckmelang.domain.post.dto.PostResponseDto;
 import umc.duckmelang.domain.post.repository.PostRepository;
 import umc.duckmelang.domain.postimage.converter.PostImageConverter;
 import umc.duckmelang.domain.postimage.repository.PostImageRepository;
@@ -33,7 +34,6 @@ import java.util.UUID;
 @RequiredArgsConstructor
 @Transactional
 public class PostCommandServiceImpl implements PostCommandService {
-
     private final PostRepository postRepository;
     private final MemberRepository memberRepository;
     private final EventCategoryRepository eventCategoryRepository;

--- a/src/main/java/umc/duckmelang/domain/post/service/PostQueryServiceImpl.java
+++ b/src/main/java/umc/duckmelang/domain/post/service/PostQueryServiceImpl.java
@@ -60,7 +60,8 @@ public class PostQueryServiceImpl implements PostQueryService{
 
     @Override
     public Page<Post> getFilteredPostListByTitle(String keyword, Gender gender, Integer minAge, Integer maxAge, Integer page, Long memberId){
-        Member member = memberRepository.findById(memberId).orElseThrow(()-> new MemberException(ErrorStatus.MEMBER_NOT_FOUND));
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(()-> new MemberException(ErrorStatus.MEMBER_NOT_FOUND));
         return postRepository.findFilteredPostsByTitle(keyword, gender, minAge, maxAge, member, PageRequest.of(page, 10));
     }
 


### PR DESCRIPTION
Resolves: #135 
## 개요
**기존**
- 검색할 때 마이페이지에서 설정한 필터가 자동 적용되었음 
- 사용자 검색 시 원하는 필터 값을 즉시 적용할 수 없었음

**개선 사항** 
- 마이페이지 설정과 별개로, 검색할 때마다 필터 값을 적용하도록 변경 
- `RequestParam` 을 사용하여 필터 값을 요청마다 반영 
- 기존 마이페이지 설정과 다르게 한 번 설정한 필터를 저장해서 유지하는 방식이 아닌, 검색할 때마다 사용자가 입력한 새로운 필터 값만을 반영해야함. 

## PR 유형
어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
