### PR TITLE
[Refactor] 채팅방 목록 조회 api의 n+1 해결

### DIFF
--- a/src/main/java/umc/duckmelang/domain/auth/oauth/CustomOAuth2UserService.java
+++ b/src/main/java/umc/duckmelang/domain/auth/oauth/CustomOAuth2UserService.java
@@ -84,7 +84,6 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
 
         //소셜 회원가입 시 알림 설정 자동 생성
         NotificationSetting notificationSetting = NotificationSetting.builder()
-                .member(savedMember)
                 .chatNotificationEnabled(true)  // 기본값을 true로 설정
                 .requestNotificationEnabled(true)
                 .reviewNotificationEnabled(true)

--- a/src/main/java/umc/duckmelang/domain/member/domain/Member.java
+++ b/src/main/java/umc/duckmelang/domain/member/domain/Member.java
@@ -131,7 +131,7 @@ public class Member extends BaseEntity {
     private List<ChatRoom> chatRoomList = new ArrayList<>();
 
     //notificationSetting
-    @OneToOne(fetch = FetchType.LAZY, mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
+    @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
     private NotificationSetting notificationSetting;
 
 

--- a/src/main/java/umc/duckmelang/domain/member/domain/Member.java
+++ b/src/main/java/umc/duckmelang/domain/member/domain/Member.java
@@ -131,7 +131,7 @@ public class Member extends BaseEntity {
     private List<ChatRoom> chatRoomList = new ArrayList<>();
 
     //notificationSetting
-    @OneToOne(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
+    @OneToOne(fetch = FetchType.LAZY, mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
     private NotificationSetting notificationSetting;
 
 

--- a/src/main/java/umc/duckmelang/domain/member/repository/MemberRepository.java
+++ b/src/main/java/umc/duckmelang/domain/member/repository/MemberRepository.java
@@ -1,9 +1,11 @@
 package umc.duckmelang.domain.member.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 import umc.duckmelang.domain.member.domain.Member;
 import umc.duckmelang.domain.member.domain.enums.MemberStatus;
+import umc.duckmelang.domain.notificationsetting.domain.NotificationSetting;
 
 import java.util.Optional;
 
@@ -12,4 +14,8 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
     Optional<Member> findByEmail(String email);
     boolean existsByEmail(String email);
     boolean existsByNickname(String nickname);
+
+
+    @Query("SELECT n from Member m JOIN m.notificationSetting n where m.id = :memberId")
+    Optional<NotificationSetting> findNotificationSettingByMemberId(Long memberId);
 }

--- a/src/main/java/umc/duckmelang/domain/member/service/member/MemberCommandServiceImpl.java
+++ b/src/main/java/umc/duckmelang/domain/member/service/member/MemberCommandServiceImpl.java
@@ -57,7 +57,6 @@ public class MemberCommandServiceImpl implements MemberCommandService {
 
         // 알림 설정 자동 추가
         NotificationSetting notificationSetting = NotificationSetting.builder()
-                .member(newMember)
                 .chatNotificationEnabled(true)  // 기본값을 true로 설정
                 .requestNotificationEnabled(true)
                 .reviewNotificationEnabled(true)

--- a/src/main/java/umc/duckmelang/domain/memberprofileimage/repository/MemberProfileImageRepository.java
+++ b/src/main/java/umc/duckmelang/domain/memberprofileimage/repository/MemberProfileImageRepository.java
@@ -1,16 +1,24 @@
 package umc.duckmelang.domain.memberprofileimage.repository;
 
+import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 import umc.duckmelang.domain.memberprofileimage.domain.MemberProfileImage;
+import umc.duckmelang.domain.postimage.domain.PostImage;
 
 @Repository
 public interface MemberProfileImageRepository extends JpaRepository<MemberProfileImage, Long> {
     Optional<MemberProfileImage> findFirstByMemberIdAndIsPublicTrueOrderByCreatedAtAsc(Long memberId);
     Page<MemberProfileImage> findAllByMemberIdAndMemberImageNot(Long memberId, String memberImage, Pageable pageable);
     Page<MemberProfileImage> findAllByIsPublicIsTrueAndMemberIdAndMemberImageNot(Long memberId, String memberImage, Pageable pageable);
+
+    @Query("SELECT mpi FROM MemberProfileImage mpi WHERE (mpi.member.id, mpi.createdAt) IN " +
+            "(SELECT mp.member.id, MIN(mp.createdAt) FROM MemberProfileImage mp WHERE mp.isPublic = true and mp.member.id IN :memberIds GROUP BY mp.member.id)")
+    List<MemberProfileImage> findFirstProfileImagesForMembers(@Param("memberIds") List<Long> memberIds);
 }

--- a/src/main/java/umc/duckmelang/domain/memberprofileimage/service/MemberProfileImageQueryService.java
+++ b/src/main/java/umc/duckmelang/domain/memberprofileimage/service/MemberProfileImageQueryService.java
@@ -3,10 +3,13 @@ package umc.duckmelang.domain.memberprofileimage.service;
 import org.springframework.data.domain.Page;
 import umc.duckmelang.domain.memberprofileimage.domain.MemberProfileImage;
 
+import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 public interface MemberProfileImageQueryService {
     Optional<MemberProfileImage> getLatestPublicMemberProfileImage(Long memberId);
     Page<MemberProfileImage> getAllMemberProfileImageByMemberId(Long memberId, Integer page);
     Page<MemberProfileImage> getPublicMemberProfileImageByMemberId(Long memberId, Integer page);
+    Map<Long, String> getFirstProfileImageUrlsForMembers(List<Long> memberIds);
 }

--- a/src/main/java/umc/duckmelang/domain/notificationsetting/controller/NotificationSettingRestController.java
+++ b/src/main/java/umc/duckmelang/domain/notificationsetting/controller/NotificationSettingRestController.java
@@ -30,7 +30,7 @@ public class NotificationSettingRestController {
     public ApiResponse<NotificationSettingResponseDto.NotificationSettingDto> getNotificationSetting(@AuthenticationPrincipal CustomUserDetails userDetails){
         Long memberId = userDetails.getMemberId();
         NotificationSetting notificationSetting = notificationSettingQueryService.findNotificationSetting(memberId);
-        return ApiResponse.onSuccess(NotificationSettingConverter.notificationSettingDto(notificationSetting));
+        return ApiResponse.onSuccess(NotificationSettingConverter.notificationSettingDto(notificationSetting, memberId));
     }
 
     @Operation(summary = "알림 설정 관리 API", description = "알림 설정을 변경합니다. 변경하지 않는 부분은 지우고, 변경할 부분만 써주세요(true/false 형식)")
@@ -40,6 +40,6 @@ public class NotificationSettingRestController {
         Long memberId = userDetails.getMemberId();
         notificationSettingCommandService.updateNotificationSetting(memberId, request);
         NotificationSetting notificationSetting = notificationSettingQueryService.findNotificationSetting(memberId);
-        return ApiResponse.onSuccess(NotificationSettingConverter.notificationSettingDto(notificationSetting));
+        return ApiResponse.onSuccess(NotificationSettingConverter.notificationSettingDto(notificationSetting, memberId));
     }
 }

--- a/src/main/java/umc/duckmelang/domain/notificationsetting/converter/NotificationSettingConverter.java
+++ b/src/main/java/umc/duckmelang/domain/notificationsetting/converter/NotificationSettingConverter.java
@@ -9,10 +9,10 @@ import umc.duckmelang.domain.notificationsetting.dto.NotificationSettingResponse
 @Component
 @RequiredArgsConstructor
 public class NotificationSettingConverter {
-    public static NotificationSettingResponseDto.NotificationSettingDto notificationSettingDto(NotificationSetting notificationSetting) {
+    public static NotificationSettingResponseDto.NotificationSettingDto notificationSettingDto(NotificationSetting notificationSetting, Long memberId) {
         return NotificationSettingResponseDto.NotificationSettingDto.builder()
                 .notificationSettingId(notificationSetting.getId())
-                .memberId(notificationSetting.getMember().getId())
+                .memberId(memberId)
                 .chatNotificationEnabled(notificationSetting.getChatNotificationEnabled())
                 .requestNotificationEnabled(notificationSetting.getRequestNotificationEnabled())
                 .reviewNotificationEnabled(notificationSetting.getReviewNotificationEnabled())

--- a/src/main/java/umc/duckmelang/domain/notificationsetting/domain/NotificationSetting.java
+++ b/src/main/java/umc/duckmelang/domain/notificationsetting/domain/NotificationSetting.java
@@ -17,10 +17,6 @@ public class NotificationSetting extends BaseEntity {
     @Column(name = "notification_setting_id", nullable = false)
     private Long id;
 
-    @OneToOne(cascade = CascadeType.PERSIST)  // PERSIST 추가
-    @JoinColumn(name = "member_id", unique = true, nullable = false)
-    private Member member;
-
     @Setter
     @Column(nullable = false)
     private Boolean chatNotificationEnabled = true;  // 채팅 알림 수신 여부

--- a/src/main/java/umc/duckmelang/domain/notificationsetting/repository/NotificationSettingRepository.java
+++ b/src/main/java/umc/duckmelang/domain/notificationsetting/repository/NotificationSettingRepository.java
@@ -10,6 +10,4 @@ import java.util.Optional;
 @Repository
 public interface NotificationSettingRepository extends JpaRepository<NotificationSetting, Long> {
 
-    @Query("SELECT n from NotificationSetting n JOIN FETCH n.member m where m.id = :memberId")
-    Optional<NotificationSetting> findByMemberId(Long memberId);
 }

--- a/src/main/java/umc/duckmelang/domain/notificationsetting/service/NotificationSettingCommandServiceImpl.java
+++ b/src/main/java/umc/duckmelang/domain/notificationsetting/service/NotificationSettingCommandServiceImpl.java
@@ -3,23 +3,22 @@ package umc.duckmelang.domain.notificationsetting.service;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import umc.duckmelang.domain.member.repository.MemberRepository;
 import umc.duckmelang.domain.notificationsetting.domain.NotificationSetting;
 import umc.duckmelang.domain.notificationsetting.dto.NotificationSettingRequestDto;
 import umc.duckmelang.domain.notificationsetting.repository.NotificationSettingRepository;
 import umc.duckmelang.global.apipayload.code.status.ErrorStatus;
 import umc.duckmelang.global.apipayload.exception.NotificationSettingException;
 
-import java.util.Map;
-
 @Service
 @RequiredArgsConstructor
 @Transactional
 public class NotificationSettingCommandServiceImpl implements NotificationSettingCommandService {
-    public final NotificationSettingRepository notificationSettingRepository;
+    public final MemberRepository memberRepository;
 
     @Override
     public void updateNotificationSetting(Long memberId, NotificationSettingRequestDto.UpdateNotificationSettingRequestDto request) {
-        NotificationSetting setting = notificationSettingRepository.findByMemberId(memberId)
+        NotificationSetting setting = memberRepository.findNotificationSettingByMemberId(memberId)
                 .orElseThrow(() -> new NotificationSettingException(ErrorStatus.NOTIFICATION_SETTING_NOT_FOUND));
 
         if (request.getChatNotificationEnabled() != null) {

--- a/src/main/java/umc/duckmelang/domain/notificationsetting/service/NotificationSettingQueryServiceImpl.java
+++ b/src/main/java/umc/duckmelang/domain/notificationsetting/service/NotificationSettingQueryServiceImpl.java
@@ -3,6 +3,7 @@ package umc.duckmelang.domain.notificationsetting.service;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import umc.duckmelang.domain.member.repository.MemberRepository;
 import umc.duckmelang.domain.notificationsetting.domain.NotificationSetting;
 import umc.duckmelang.domain.notificationsetting.repository.NotificationSettingRepository;
 import umc.duckmelang.global.apipayload.code.status.ErrorStatus;
@@ -12,11 +13,11 @@ import umc.duckmelang.global.apipayload.exception.NotificationSettingException;
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class NotificationSettingQueryServiceImpl implements NotificationSettingQueryService {
-    private final NotificationSettingRepository notificationSettingRepository;
+    private final MemberRepository memberRepository;
 
     @Override
     public NotificationSetting findNotificationSetting(Long memberId){
-        return notificationSettingRepository.findByMemberId(memberId)
+        return memberRepository.findNotificationSettingByMemberId(memberId)
                 .orElseThrow(() -> new NotificationSettingException(ErrorStatus.NOTIFICATION_SETTING_NOT_FOUND));
 
     }

--- a/src/main/java/umc/duckmelang/domain/postimage/repository/PostImageRepository.java
+++ b/src/main/java/umc/duckmelang/domain/postimage/repository/PostImageRepository.java
@@ -7,7 +7,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import umc.duckmelang.domain.postimage.domain.PostImage;
 import umc.duckmelang.domain.postimage.dto.PostThumbnailResponseDto;
-import java.util.Optional;
+import java.util.*;
 
 public interface PostImageRepository extends JpaRepository<PostImage, Long> {
     @Query("SELECT new umc.duckmelang.domain.postimage.dto.PostThumbnailResponseDto(p.id, pi.postImageUrl, pi.createdAt) " +
@@ -18,6 +18,10 @@ public interface PostImageRepository extends JpaRepository<PostImage, Long> {
     Page<PostThumbnailResponseDto> findLatestPostImagesForMemberPosts(@Param("memberId") Long memberId, Pageable pageable);
 
     Optional<PostImage> findFirstByPostIdOrderByCreatedAtAsc(Long postId);
+
+    @Query("SELECT pi FROM PostImage pi WHERE (pi.post.id, pi.createdAt) IN " +
+            "(SELECT p.post.id, MIN(p.createdAt) FROM PostImage p WHERE p.post.id IN :postIds GROUP BY p.post.id)")
+    List<PostImage> findFirstImagesForPosts(@Param("postIds") List<Long> postIds);
 }
 
 

--- a/src/main/java/umc/duckmelang/domain/postimage/service/PostImageQueryService.java
+++ b/src/main/java/umc/duckmelang/domain/postimage/service/PostImageQueryService.java
@@ -1,7 +1,9 @@
 package umc.duckmelang.domain.postimage.service;
 
-import java.util.Optional;
+import java.util.Map;
+import java.util.*;
 import org.springframework.data.domain.Page;
+import umc.duckmelang.domain.postimage.domain.PostImage;
 import umc.duckmelang.domain.postimage.dto.PostThumbnailResponseDto;
 
 public interface PostImageQueryService {
@@ -12,4 +14,6 @@ public interface PostImageQueryService {
 
     //추후 memberId가 아닌 jwt 사용
     Page<PostThumbnailResponseDto> getMyPostsImage(Long memberId, int page);
+
+    Map<Long, String> getFirstImageUrlsForPosts(List<Long> postIds);
 }

--- a/src/main/java/umc/duckmelang/domain/postimage/service/PostImageQueryServiceImpl.java
+++ b/src/main/java/umc/duckmelang/domain/postimage/service/PostImageQueryServiceImpl.java
@@ -1,19 +1,30 @@
 package umc.duckmelang.domain.postimage.service;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import umc.duckmelang.domain.postimage.converter.PostImageConverter;
+import umc.duckmelang.domain.postimage.domain.PostImage;
 import umc.duckmelang.domain.postimage.dto.PostThumbnailResponseDto;
 import umc.duckmelang.domain.postimage.repository.PostImageRepository;
 import umc.duckmelang.global.apipayload.code.status.ErrorStatus;
 import umc.duckmelang.global.apipayload.exception.PostImageException;
 
+import java.util.Collections;
+import java.util.Map;
+import java.util.List;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
 @Service
 @RequiredArgsConstructor
 public class PostImageQueryServiceImpl implements PostImageQueryService {
     private final PostImageRepository postImageRepository;
+
+    @Value("${spring.custom.default.profile-image}")
+    private String defaultImage;
 
     @Override
     public PostThumbnailResponseDto getLatestPostImage(Long postId) {
@@ -30,5 +41,29 @@ public class PostImageQueryServiceImpl implements PostImageQueryService {
     @Override
     public Page<PostThumbnailResponseDto> getMyPostsImage(Long memberId, int page) {
         return postImageRepository.findLatestPostImagesForMemberPosts(memberId, PageRequest.of(page, 10));
+    }
+
+    @Override
+    public Map<Long, String> getFirstImageUrlsForPosts(List<Long> postIds) {
+        if (postIds.isEmpty()) {
+            return Collections.emptyMap();
+        }
+
+        // 조회된 이미지들을 Map으로 변환
+        Map<Long, String> imageMap = postImageRepository.findFirstImagesForPosts(postIds)
+                .stream()
+                .collect(Collectors.toMap(
+                        image -> image.getPost().getId(),
+                        PostImage::getPostImageUrl,
+                        (a, b) -> a
+                ));
+
+        // 최종 결과 생성
+        return postIds.stream()
+                .distinct()
+                .collect(Collectors.toMap(
+                        Function.identity(),
+                        postId -> imageMap.getOrDefault(postId, defaultImage)
+                ));
     }
 }


### PR DESCRIPTION
## 개요
https://github.com/duckmelang/duckmelang-backend/issues/131
노션에 페이지 올리겠습니다!
application.yml에 채팅방 목록 전체 조회 api에서 spring: jpa: show-sql: true 설정해두시고
스웨거에서 채팅방 전체 목록 조회 api 돌렸을 때 쿼리문 개수 차이 봐주시면 됩니다

## PR 유형
어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
