### PR TITLE
Fix: 회원가입에서 isProfileComplete 을 false로 변경

### DIFF
--- a/src/main/java/umc/duckmelang/domain/member/converter/MemberConverter.java
+++ b/src/main/java/umc/duckmelang/domain/member/converter/MemberConverter.java
@@ -25,7 +25,7 @@ public class MemberConverter {
                 .email(request.getEmail())
                 .password(request.getPassword())
                 .memberStatus(MemberStatus.ACTIVE)
-                .isProfileComplete(true) // 일반 회원가입 사용자는 true
+                .isProfileComplete(false)
                 .build();
     }
 


### PR DESCRIPTION
Resolves: #142 
## 개요
회원가입을 했을 때 프로필 설정을 아직 다 한 상태가 아니기 때문에 isProfileComplete이 false가 되어야한다는걸 깜빡했습니다. 그래서 수정하게 되었습니다. 

## PR 유형
어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
