### PR TITLE
[!HOTFIX] 지뢰 키워드 미설정 시 프로필 설정 완료가 되지 않는 문제 해결

### DIFF
--- a/src/main/java/umc/duckmelang/domain/member/service/member/MemberCommandServiceImpl.java
+++ b/src/main/java/umc/duckmelang/domain/member/service/member/MemberCommandServiceImpl.java
@@ -117,14 +117,14 @@ public class MemberCommandServiceImpl implements MemberCommandService {
     public List<Landmine> createLandmines(Long memberId, MemberRequestDto.CreateLandminesDto request) {
         Member member = getMemberOrThrow(memberId);
 
-        if (request.getLandmineContents() == null || request.getLandmineContents().isEmpty()) {
-            return Collections.emptyList();
+        List<Landmine> landmineList = Collections.emptyList();
+        if (request.getLandmineContents() != null && !request.getLandmineContents().isEmpty()) {
+            landmineList = request.getLandmineContents().stream()
+                    .map(content -> MemberConverter.toLandmine(member, content))
+                    .collect(Collectors.toList());
+
+            landmineRepository.saveAll(landmineList);
         }
-
-        List<Landmine> landmineList = request.getLandmineContents().stream()
-                .map(content -> MemberConverter.toLandmine(member, content))
-                .collect(Collectors.toList());
-
         member.completeProfile();
         return landmineRepository.saveAll(landmineList);
     }


### PR DESCRIPTION
## ✨개요
지뢰 키워드 미설정 시 프로필 설정 완료가 되지 않는 문제 해결했습니다. 

## 🌱 Issue Number
<!-- #뒤에 이슈넘버 써주시면 자동으로 이슈페이지 연결이 됩니다!-->
-

## PR 유형
> 어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist
> PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
