### PR TITLE
[Bug] 탈퇴한 회원의 프로필 조회 처리 

### DIFF
--- a/src/main/java/umc/duckmelang/domain/auth/controller/AuthRestController.java
+++ b/src/main/java/umc/duckmelang/domain/auth/controller/AuthRestController.java
@@ -16,6 +16,8 @@ import umc.duckmelang.domain.auth.dto.response.LoginResponse;
 import umc.duckmelang.domain.auth.dto.response.PhoneNumResponse;
 import umc.duckmelang.domain.auth.service.AuthService;
 import umc.duckmelang.domain.auth.user.CustomUserDetails;
+import umc.duckmelang.domain.member.service.profileImage.MemberProfileImageCommandService;
+import umc.duckmelang.domain.member.service.profileImage.MemberProfileImageCommandServiceImpl;
 import umc.duckmelang.global.apipayload.ApiResponse;
 
 @RestController
@@ -24,6 +26,7 @@ import umc.duckmelang.global.apipayload.ApiResponse;
 @Tag(name = "Auth", description = "인증 API")
 public class AuthRestController {
     private final AuthService authService;
+    private final MemberProfileImageCommandService memberProfileImageCommandService;
 
     @PostMapping("/login")
     @Operation(summary = "로그인 API", description = "RefreshToken과 AccessToken을 발급합니다.")
@@ -81,7 +84,7 @@ public class AuthRestController {
     @Operation(summary = "회원 탈퇴 API", description = "회원 탈퇴를 처리합니다.")
     @DeleteMapping("/me")
     public ApiResponse<String> deleteMember(@AuthenticationPrincipal CustomUserDetails userDetails){
-        authService.deleteMember(userDetails.getMemberId());
+        memberProfileImageCommandService.deleteMember(userDetails.getMemberId());
         return ApiResponse.onSuccess("성공적으로 탈퇴했습니다.");
     }
 }

--- a/src/main/java/umc/duckmelang/domain/auth/service/AuthService.java
+++ b/src/main/java/umc/duckmelang/domain/auth/service/AuthService.java
@@ -15,7 +15,6 @@ import umc.duckmelang.domain.member.domain.Member;
 import umc.duckmelang.domain.member.domain.enums.MemberStatus;
 import umc.duckmelang.domain.member.domain.enums.Role;
 import umc.duckmelang.domain.member.repository.MemberRepository;
-import umc.duckmelang.domain.notification.repository.NotificationRepository;
 import umc.duckmelang.global.apipayload.exception.MemberException;
 import umc.duckmelang.global.apipayload.exception.TokenException;
 import umc.duckmelang.domain.auth.refreshToken.RefreshTokenServiceImpl;
@@ -33,7 +32,6 @@ public class AuthService {
     private final KakaoApiClient kakaoApiClient;
 
     private final MemberRepository memberRepository;
-    private final BookmarkRepository bookmarkRepository;
 
     // 자체 로그인
     @Transactional
@@ -134,22 +132,5 @@ public class AuthService {
         Member member = memberRepository.findByLoginId(loginId)
                 .orElseThrow(() -> new MemberException(ErrorStatus.MEMBER_NOT_FOUND));
         member.updatePassword(passwordEncoder.encode(newPassword));
-    }
-
-    @Transactional
-    public void deleteMember(Long memberId) {
-        Member member = findMemberOrThrow(memberId);
-        member.deleteMember();
-
-        // 프로필 이미지 삭제
-        member.getMemberProfileImageList().clear();
-
-        // 좋아하는 아이돌/행사/지뢰키워드 삭제
-        member.getMemberIdolList().clear();
-        member.getMemberEventList().clear();
-        member.getLandmineList().clear();
-
-        // 북마크 삭제
-        bookmarkRepository.deleteAllByMember(member);
     }
 }

--- a/src/main/java/umc/duckmelang/domain/member/converter/MemberProfileConverter.java
+++ b/src/main/java/umc/duckmelang/domain/member/converter/MemberProfileConverter.java
@@ -5,13 +5,15 @@ import umc.duckmelang.domain.member.domain.Member;
 import umc.duckmelang.domain.member.dto.mypage.MyPageResponseDto;
 import umc.duckmelang.domain.member.domain.MemberProfileImage;
 
+import static umc.duckmelang.domain.member.util.NicknameUtil.getDisplayName;
+
 @Component
 public class MemberProfileConverter {
 
     public static MyPageResponseDto.MyPagePreviewDto toGetMemberPreviewResponseDto(Member member, MemberProfileImage memberProfileImage) {
         return MyPageResponseDto.MyPagePreviewDto.builder()
                 .memberId(member.getId())
-                .nickname(member.getNickname())
+                .nickname(getDisplayName(member))
                 .gender(member.getGender())
                 .age(member.calculateAge())
                 .latestPublicMemberProfileImage(memberProfileImage.getMemberImage())
@@ -21,7 +23,7 @@ public class MemberProfileConverter {
     public static MyPageResponseDto.MyPageProfileDto toGetProfileResponseDto(Member member, MemberProfileImage memberProfileImage, long postCount, long matchCount) {
         return  MyPageResponseDto.MyPageProfileDto.builder()
                 .memberId(member.getId())
-                .nickname(member.getNickname())
+                .nickname(getDisplayName(member))
                 .gender(member.getGender())
                 .age(member.calculateAge())
                 .latestPublicMemberProfileImage(memberProfileImage.getMemberImage())

--- a/src/main/java/umc/duckmelang/domain/member/service/profileImage/MemberProfileImageCommandService.java
+++ b/src/main/java/umc/duckmelang/domain/member/service/profileImage/MemberProfileImageCommandService.java
@@ -8,4 +8,5 @@ public interface MemberProfileImageCommandService {
     void deleteProfileImage(Long memberId, Long imageId);
     MemberProfileImage updateProfileImageStatus(Long memberId, Long imageId, MemberProfileImageRequestDto.UpdateProfileImageStatusDto request);
     MemberProfileImage createProfileImage(Long memberId, MultipartFile profileImage);
+    void deleteMember(Long memberId);
 }

--- a/src/main/java/umc/duckmelang/domain/member/service/profileImage/MemberProfileImageCommandServiceImpl.java
+++ b/src/main/java/umc/duckmelang/domain/member/service/profileImage/MemberProfileImageCommandServiceImpl.java
@@ -5,6 +5,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
+import umc.duckmelang.domain.bookmark.repository.BookmarkRepository;
 import umc.duckmelang.domain.member.domain.Member;
 import umc.duckmelang.domain.member.repository.MemberRepository;
 import umc.duckmelang.domain.member.converter.MemberProfileImageConverter;
@@ -19,6 +20,7 @@ import umc.duckmelang.global.apipayload.exception.MemberException;
 import umc.duckmelang.global.apipayload.exception.MemberProfileImageException;
 import umc.duckmelang.global.aws.AmazonS3Manager;
 
+import java.util.List;
 import java.util.UUID;
 
 @Service
@@ -26,6 +28,8 @@ import java.util.UUID;
 public class MemberProfileImageCommandServiceImpl implements MemberProfileImageCommandService {
     private final MemberProfileImageRepository memberProfileImageRepository;
     private final MemberRepository memberRepository;
+    private final BookmarkRepository bookmarkRepository;
+
     private final UuidService uuidService;
     private final AmazonS3Manager s3Manager;
 
@@ -56,6 +60,25 @@ public class MemberProfileImageCommandServiceImpl implements MemberProfileImageC
         validateProfileImage(profileImage, memberId);
         profileImage.changeStatus(request.isPublicStatus());
         return memberProfileImageRepository.save(profileImage);
+    }
+
+    @Transactional
+    public void deleteMember(Long memberId) {
+        Member member = getMemberOrThrow(memberId);
+        member.deleteMember();
+
+        // 디폴트 이미지를 제외한 프로필 이미지 삭제
+        List<MemberProfileImage> toDelete = member.getMemberProfileImageList().stream()
+                .filter(image -> !defaultProfileImage.equals(image.getMemberImage()))
+                .toList();
+
+        toDelete.forEach(image -> memberProfileImageRepository.delete(image));
+
+        member.getMemberIdolList().clear();
+        member.getMemberEventList().clear();
+        member.getLandmineList().clear();
+
+        bookmarkRepository.deleteAllByMember(member);
     }
 
     private Member getMemberOrThrow(Long memberId) {


### PR DESCRIPTION
## ✨개요
탈퇴한 회원의 프로필 이미지 전체를 삭제하는 과정이어서, 탈퇴한 회원의 프로필 조회가 어려운 상황이었습니다. 
탈퇴한 회원의 프로필 이미지를 삭제하는 과정에서 디폴트 이미지는 남겨두어서, 탈퇴한 회원의 포로필 조회가 가능하도록 수정했습니다. 

## 🌱 Issue Number
<!-- #뒤에 이슈넘버 써주시면 자동으로 이슈페이지 연결이 됩니다!-->
- #224 

## PR 유형
> 어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist
> PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
